### PR TITLE
Add "HEAST"-Keyword

### DIFF
--- a/keywords.json
+++ b/keywords.json
@@ -53,4 +53,5 @@
     "HOST MI": "?",
     "DANN HOIT NET": ":",
     "HUACH ZUA": "=>"
+    "HEAST": "alert"
 }


### PR DESCRIPTION
No implementation of WIenerScript should be missing the most iconic Viennese interjection.

I've added "HEAST" as an alias for "alert" to not break existing WS sourcecode. 
The "alert"-function (while not essential to writing JS code like logical operators or much needed functionality like console.log) is the best fit for the implied urgency of a heartfelt "HEAST!", while being just as easily dismissable.